### PR TITLE
fix: 仅白名单

### DIFF
--- a/src/utils/ratelimiter.go
+++ b/src/utils/ratelimiter.go
@@ -71,9 +71,6 @@ func InitGlobalLimiter() *IPRateLimiter {
 	ratePerSecond := rate.Limit(float64(cfg.RateLimit.RequestLimit) / (cfg.RateLimit.PeriodHours * 3600))
 
 	burstSize := cfg.RateLimit.RequestLimit
-	if burstSize < 1 {
-		burstSize = 1
-	}
 
 	limiter := &IPRateLimiter{
 		ips:              make(map[string]*rateLimiterEntry),


### PR DESCRIPTION
close https://github.com/sky22333/hubproxy/issues/50 & https://github.com/sky22333/hubproxy/issues/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated rate limiter behavior to allow burst size values below 1, reflecting configuration settings directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->