### PR TITLE
新增拉取功能

### DIFF
--- a/src/public/search.html
+++ b/src/public/search.html
@@ -1353,6 +1353,7 @@
         }
 
         function renderTagsBatch(tags, fullRepoName, container, replaceContent = false) {
+             const proxyDomain = window.location.host;
             const tagsHtml = tags.map(tag => {
                 const vulnIndicators = Object.entries(tag.vulnerabilities || {})
                     .map(([level, count]) => count > 0 ? `<span class="vulnerability-dot vulnerability-${level.toLowerCase()}" title="${level}: ${count}"></span>` : '')
@@ -1364,6 +1365,8 @@
                     const size = formatUtils.formatSize(img.size);
                     return `<div class="arch-item" title="大小: ${size}">${arch}</div>`;
                 }).join('');
+                
+                const proxyCommand = `docker pull ${proxyDomain}/${fullRepoName}:${tag.name} && docker tag ${proxyDomain}/${fullRepoName}:${tag.name} ${fullRepoName}:${tag.name} && docker rmi ${proxyDomain}/${fullRepoName}:${tag.name}`;
 
                 return `
                     <div class="tag-item">
@@ -1379,6 +1382,10 @@
                         <div class="tag-pull-command">
                             docker pull ${fullRepoName}:${tag.name}
                             <button class="copy-button" onclick="copyToClipboard('docker pull ${fullRepoName}:${tag.name}')">复制</button>
+                        </div>
+                        <div class="tag-pull-command">
+                            ${proxyCommand}
+                            <button class="copy-button" onclick="copyToClipboard('${proxyCommand.replace(/'/g, '\\\'')}')">复制</button>
                         </div>
                         ${architectures ? `<div class="tag-architectures">${architectures}</div>` : ''}
                     </div>
@@ -1488,4 +1495,4 @@
     </script>
     </main>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
在原有镜像搜索拉取镜像命令下方新增使用代理拉取镜像并tag回源镜像再untag代理镜像。实现效果如下
<img width="1305" height="859" alt="eie31lf1 2pw" src="https://github.com/user-attachments/assets/1278f929-a3cb-45d6-99b9-1a80b04fb963" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Docker pull command option that uses the current page's host as a proxy domain prefix.
  * Both the original and proxy pull commands are now displayed with copy buttons for convenience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->