### PR TITLE
🔒️✨ docker: Support basic auth for docker hub

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -46,11 +46,16 @@ blackList = [
 # 无认证: socks5://127.0.0.1:1080
 # 有认证: socks5://username:password@127.0.0.1:1080
 # 留空不使用代理
-proxy = "" 
+proxy = ""
 
 [download]
 # 批量下载离线镜像数量限制
 maxImages = 10
+
+# Docker Hub 认证信息，留空则匿名拉取
+[dockerHubAuth]
+username = "" # e.g., user1
+token = "" # e.g., dckr_pat_***
 
 # Registry映射配置，支持多种镜像仓库上游
 [registries]
@@ -58,7 +63,7 @@ maxImages = 10
 # GitHub Container Registry
 [registries."ghcr.io"]
 upstream = "ghcr.io"
-authHost = "ghcr.io/token" 
+authHost = "ghcr.io/token"
 authType = "github"
 enabled = true
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -113,6 +113,13 @@ func DefaultConfig() *AppConfig {
 		}{
 			MaxImages: 10,
 		},
+		DockerHubAuth: struct {
+			Username string `toml:"username"`
+			Token    string `toml:"token"`
+		}{
+			Username: "",
+			Token:    "",
+		},
 		Registries: map[string]RegistryMapping{
 			"ghcr.io": {
 				Upstream: "ghcr.io",

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -48,6 +48,11 @@ type AppConfig struct {
 		MaxImages int `toml:"maxImages"`
 	} `toml:"download"`
 
+	DockerHubAuth struct {
+		Username string `toml:"username"`
+		Token    string `toml:"token"`
+	} `toml:"dockerHubAuth"`
+
 	Registries map[string]RegistryMapping `toml:"registries"`
 
 	TokenCache struct {

--- a/src/handlers/docker.go
+++ b/src/handlers/docker.go
@@ -68,9 +68,17 @@ func InitDockerProxy() {
 	}
 
 	options := []remote.Option{
-		remote.WithAuth(authn.Anonymous),
 		remote.WithUserAgent("hubproxy/go-containerregistry"),
 		remote.WithTransport(utils.GetGlobalHTTPClient().Transport),
+	}
+	dockerHubAuth := config.GetConfig().DockerHubAuth
+	if dockerHubAuth.Token != "" && dockerHubAuth.Username != "" {
+		options = append(options, remote.WithAuth(&authn.Basic{
+			Username: dockerHubAuth.Username,
+			Password: dockerHubAuth.Token,
+		}))
+	} else {
+		options = append(options, remote.WithAuth(authn.Anonymous))
 	}
 
 	dockerProxy = &DockerProxy{


### PR DESCRIPTION
# 初步支持 docker hub 认证拉取
1. 考虑到 docker hub 的拉取流程独立于自定义上游进行，因此相应配置也独立于 registries 数组
2. 默认配置中，认证信息留空（匿名拉取）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Docker Hub authentication. You can now provide a username and token in the app configuration to enable authenticated pulls.
  * When credentials are supplied, the app automatically uses basic authentication; if not, it continues with anonymous access.
  * Default behavior remains unchanged for users who do not configure credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->