### PR TITLE
Fix access control check for repository name

### DIFF
--- a/src/utils/access_control.go
+++ b/src/utils/access_control.go
@@ -192,7 +192,7 @@ func (ac *AccessController) checkList(matches, list []string) bool {
 
 		if strings.HasSuffix(item, "*") {
 			prefix := strings.TrimSuffix(item, "*")
-			if strings.HasPrefix(fullRepo, prefix) {
+			if strings.HasPrefix(repoName, prefix) {
 				return true
 			}
 		}


### PR DESCRIPTION
should fix #89 

前缀匹配应该对比仓库名称（reponame）而不是完整名称（fullname）